### PR TITLE
Fix a typo in property names

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,8 +22,8 @@ main = defaultMain tests
 
 tests = [
     testGroup "Properties" [
-      testProperty "rndSelect returns result of correct length" (lenProp :: Int -> [Int] -> NonNegative Int -> Bool),
-      testProperty "rndSelect returns result of correct length" (lenProp :: Int -> String -> NonNegative Integer -> Bool),
+      testProperty "rndGenSelect returns result of correct length" (lenProp :: Int -> [Int] -> NonNegative Int -> Bool),
+      testProperty "rndGenSelect returns result of correct length" (lenProp :: Int -> String -> NonNegative Integer -> Bool),
       testProperty "rndGenSelect returns empty result when count is negative" (negLenProp :: Int -> [Int] -> Positive Int -> Bool)
     ],
     testGroup "Regression tests" $ hUnitTestToTests $ TestList [


### PR DESCRIPTION
I *might* have a bigger PR coming, but I thought I should fix those typos now. (Are they typos? I think so.)